### PR TITLE
#165305748 Configure Authors Haven to use PostgreSQL as DB Engine

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,6 @@
+# These database variables establishes a connection between the application and your local database setup
+
+DATABASE_NAME=your database name
+DATABASE_USER=your user name
+DATABASE_PASSWORD=your user password
+DATABASE_HOST=your host

--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,8 @@ ENV/
 # SQLite3
 db.sqlite3
 
-#vscode
+# DS_Store
+.DS_Store
+
+# vscode
 .vscode/

--- a/README.md
+++ b/README.md
@@ -391,6 +391,29 @@ No additional parameters required
 
 `GET /api/tags`
 
+## Local Setup
+ - First Create python virtual env
+ ```
+  $ virtualenv -p python3 env
+ ```
+ - Install Requirements
+ ```
+  $ pip install -r requirements.txt
+ ```
+ - Create a .env file and set variables as in the .env-example
 
-
-
+ - Create postgres database
+ ```
+  $ psql postgres
+  postgres=# CREATE USER your-user WITH PASSWORD 'your-password';
+  postgres=# ALTER ROLE your-user SET client_encoding TO 'utf8';
+  postgres=# ALTER ROLE your-user SET default_transaction_isolation TO 'read committed';
+  postgres=# ALTER ROLE your-user SET timezone TO 'UTC';
+  postgres=# CREATE DATABASE your-database-name;
+  postgres=# GRANT ALL PRIVILEGES ON DATABASE your-database-name TO your-user;
+  postgres=# \q
+ ```
+ - Run Server
+ ```
+  $ python manage.py runserver
+ ```

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    # 'corsheaders.middleware.CorsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -81,8 +81,12 @@ WSGI_APPLICATION = 'authors.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.getenv('DATABASE_NAME'),
+        'USER': os.getenv('DATABASE_USER'),
+        'PASSWORD': os.getenv('DATABASE_PASSWORD'),
+        'HOST': os.getenv('DATABASE_HOST'),
+        'PORT': '',
     }
 }
 
@@ -138,6 +142,6 @@ REST_FRAMEWORK = {
     'NON_FIELD_ERRORS_KEY': 'error',
 
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        # 'authors.apps.authentication.backends.JWTAuthentication',
+        'authors.apps.authentication.backends.JWTAuthentication',
     ),
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ djangorestframework==3.9.2
 isort==4.3.16
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
+psycopg2-binary==2.8.2
 PyJWT==1.4.2
 pylint==2.3.1
 pytz==2019.1


### PR DESCRIPTION
#### Description
Currently, Authors Haven is using the default SQLite3 database engine which is not ideal for production environment. This chore adds PostgreSQL as DB Engine because it is Open Source, fully featured and optimised for production ready environments as compared to SQLite. 

#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [ ] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [ ]  Integration test
- [ ]  Unit test

#### Checklist:
- [ ] My code follows the style guide for this project
- [ ] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
[#165305748](https://www.pivotaltracker.com/story/show/165305748)