### PR TITLE
#165305758 Fix profiles feature

### DIFF
--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -11,11 +11,14 @@ class UserProfileSerializer(serializers.ModelSerializer):
     username = serializers.ReadOnlyField(source='fetch_username')
     img_url = serializers.ReadOnlyField(source='fetch_image')
     created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+
     class Meta:
         model = Profile
         fields = (
-            'username', 'first_name', 'last_name', 'bio', 'img_url', 'created_at'
+            'username', 'first_name', 'last_name', 'bio', 'img_url', 'created_at', 'updated_at'
         )
+
 
 class UpdateUserProfileSerializer(serializers.ModelSerializer):
     """
@@ -36,6 +39,8 @@ class FollowingSerializer(serializers.ModelSerializer):
     class Meta:
         model = Followers
         fields = ('profile', 'followed')
+
+
 class UserListSerializer(serializers.ModelSerializer):
     """
     Serializer class for getting user profile

--- a/authors/apps/profiles/tests/basetests.py
+++ b/authors/apps/profiles/tests/basetests.py
@@ -27,7 +27,7 @@ class BaseTest(APITestCase):
             password="@Us3r.com"
         )
 
-        self.user.is_verified=True
+        self.user.is_verified = True
         self.user.save()
 
         self.user1 = User.objects.create_user(
@@ -36,7 +36,7 @@ class BaseTest(APITestCase):
             password="@Us3r.com"
         )
 
-        self.user1.is_verified=True
+        self.user1.is_verified = True
         self.user1.save()
 
     def login_user(self, email="", password=""):
@@ -131,6 +131,7 @@ class BaseTest(APITestCase):
             ),
             content_type="application/json"
         )
+
     def list_profiles(self):
         """
         Method to get all profiles

--- a/authors/apps/profiles/tests/test_profiles.py
+++ b/authors/apps/profiles/tests/test_profiles.py
@@ -24,16 +24,18 @@ class TestViewProfile(BaseTest):
         self.is_authenticated("adam@gmail.com", "@Us3r.com")
         response = self.get_profile_with_invalid_username()
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.data.get("error"), "User does not exist")
+        self.assertEqual(response.data.get("errors").get("user")[0], "User does not exist")
 
     def test_update_profile_successfuly(self):
         """
         Test method for successfully updtaing a user
         """
         self.is_authenticated("adam@gmail.com", "@Us3r.com")
-        response = self.update_user_profile("Abraham", "Kamau", "I love history")
+        response = self.update_user_profile(
+            "Abraham", "Kamau", "I love history")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get("profile").get("last_name"), "Kamau")
+        self.assertEqual(response.data.get(
+            "profile").get("last_name"), "Kamau")
 
     def test_update_profile_while_loggedout(self):
         """
@@ -42,7 +44,8 @@ class TestViewProfile(BaseTest):
         response = self.update_user_profile(
             "Abraham", "Kamau", "I love history")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data.get("detail"), "Authentication credentials were not provided.")
+        self.assertEqual(response.data.get("detail"),
+                         "Authentication credentials were not provided.")
 
     def test_update_profile_while_not_owner(self):
         """
@@ -52,8 +55,9 @@ class TestViewProfile(BaseTest):
         response = self.update_another_user_profile(
             "Abraham", "Kamau", "I love history")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data.get("error"), "You do not own this profile")
-    
+        self.assertEqual(response.data.get("errors").get("user")[0],
+                         "You do not own this profile")
+
     def test_update_profile_while_not_exist(self):
         """
         Test method for updating while user is not owner
@@ -62,7 +66,7 @@ class TestViewProfile(BaseTest):
         response = self.update_user_profile_notexist(
             "Abraham", "Kamau", "I love history")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.data.get("error"), "User does not exist")
+        self.assertEqual(response.data.get("errors").get("user")[0], "User does not exist")
 
     def test_successfully_listing_profiles(self):
         """

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -3,9 +3,11 @@ from django.urls import include, path
 from django.conf.urls import url
 from .views import FollowAPI, FollowersAPI
 
-from authors.apps.profiles.views import (UserProfileView, UpdateUserProfileView, UserListView)
+from authors.apps.profiles.views import (
+    UserProfileView, UpdateUserProfileView, UserListView)
 
-from authors.apps.profiles.views import (UserProfileView, UpdateUserProfileView)
+from authors.apps.profiles.views import (
+    UserProfileView, UpdateUserProfileView)
 
 app_name = 'profiles'
 
@@ -15,6 +17,7 @@ urlpatterns = [
          UpdateUserProfileView.as_view(), name='update_profile'),
     path('profiles/<username>/followers/', FollowersAPI.as_view()),
     path('profiles/<username>/follow/', FollowAPI.as_view()),
-    path('profiles/<str:username>/', UpdateUserProfileView.as_view(), name='update_profile'),
+    path('profiles/<str:username>/',
+         UpdateUserProfileView.as_view(), name='update_profile'),
     path('profiles/', UserListView.as_view(), name='list_users'),
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -26,9 +26,11 @@ class UserProfileView(GenericAPIView):
         try:
             profile = Profile.objects.get(user__username=username)
         except Exception:
-             return Response({
-                 "error": "User does not exist"
-             }, status = status.HTTP_404_NOT_FOUND)
+            return Response({
+                'errors': {
+                    'user': ['User does not exist']
+                }
+            }, status=status.HTTP_404_NOT_FOUND)
 
         serializer = UserProfileSerializer(
             profile, context={'request': request}
@@ -37,6 +39,7 @@ class UserProfileView(GenericAPIView):
         return Response({
             'profile': serializer.data
         }, status=status.HTTP_200_OK)
+
 
 class UpdateUserProfileView(GenericAPIView):
     """
@@ -52,20 +55,24 @@ class UpdateUserProfileView(GenericAPIView):
         try:
             profile = Profile.objects.get(user__username=username)
         except Exception:
-             return Response({
-                 "error": "User does not exist"
-             }, status = status.HTTP_404_NOT_FOUND)
+            return Response({
+                'errors': {
+                    'user': ['User does not exist']
+                }
+            }, status=status.HTTP_404_NOT_FOUND)
         user_name = request.user.username
         if user_name != username:
             return Response({
-                'error': 'You do not own this profile'
+                'errors': {
+                    'user': ['You do not own this profile']
+                }
             }, status=status.HTTP_403_FORBIDDEN)
 
         data = request.data
 
         serializer = UpdateUserProfileSerializer(
             instance=request.user.profile,
-            data=data, 
+            data=data,
             partial=True
         )
         serializer.is_valid()
@@ -189,6 +196,8 @@ class FollowersAPI(GenericAPIView):
             response = {
                 'count': len(profiles), 'current_followers': profiles}
         return Response(response, status=status.HTTP_200_OK)
+
+
 class UserListView(GenericAPIView):
     """
     A class for getting all user profiles
@@ -200,4 +209,4 @@ class UserListView(GenericAPIView):
         serializer = UserListSerializer(queryset, many=True)
         return Response({
             'profiles': serializer.data
-            }, status=status.HTTP_200_OK)
+        }, status=status.HTTP_200_OK)


### PR DESCRIPTION
#### Description
When a user registers into the platform, a profile is created with the default registration details(username). A user can update the rest of the details(first name, last name, image, bio) on his profile. A user can then get a profile for another user while logged in.
**This PR fixes the error messages that the user gets when the profile entered is not the owner during an update and when the profile does not exist in the database and adds the updated_at field in the response**

#### Type of change
- [x] Bug fix (nonbreaking change which fixes an issue)
- [ ] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [ ] End to end
- [x] Integration

#### Checklist:
- [x] My code follows the style guide for this project
- [x] I have linted my code prior to submission
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
[#165305758](https://www.pivotaltracker.com/n/projects/2326460/stories/165305758)