### PR TITLE
#165305757 Fix Error Messages in Social Login Feature

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -214,17 +214,38 @@ class SocialAuthSerializer(serializers.Serializer):
 
     provider = serializers.CharField(
         max_length=30,
-        required=True
+        allow_blank=True
     )
     access_token = serializers.CharField(
         max_length=255,
-        required=True
+        allow_blank=True
     )
     access_token_secret = serializers.CharField(
         max_length=255,
         allow_blank=True,
         default=""
     )
+
+    def validate(self, data):
+        """Method to validate provider and access token"""
+        provider = data.get('provider', None)
+        access_token = data.get('access_token', None)
+        access_token_secret = data.get('access_token_secret', None)
+        if not provider:
+            raise serializers.ValidationError(
+                'A provider is required for Social Login'
+            )
+
+        if not access_token:
+            raise serializers.ValidationError(
+                'An access token is required for Social Login'
+            )
+
+        if provider == 'twitter' and not access_token_secret:
+            raise serializers.ValidationError(
+                'An access token secret is required for Twitter Login'
+            )
+        return data
 
 
 class PasswordResetSerializer(serializers.Serializer):

--- a/authors/apps/authentication/tests/test_social_auth.py
+++ b/authors/apps/authentication/tests/test_social_auth.py
@@ -54,6 +54,22 @@ class TestSocialLogin(BaseTest):
                 "error": "Provider invalid or not supported"
                 }
 
+        self.missing_token = {
+            "provider": "facebook",
+            "access_token": ""
+        }
+
+        self.missing_provider = {
+            "provider": "",
+            "access_token": "96930231-8iCEKaIwsSlQCSpHhFWD7WOJj5KXAN9CZFUkTK"
+        }
+
+        self.missing_token_secret = {
+            "provider": "twitter",
+            "access_token": "96930231-NeiGSUbnIrSjjEQY7LPmZc7Ge7J7FPXIzrHjTLMT4",
+            "access_token_secret": ""
+        }
+
     def test_successful_login_with_google(self):
         """
         Test successful login with google
@@ -115,3 +131,27 @@ class TestSocialLogin(BaseTest):
         res = self.social_login(self.social_url, self.invalid_token)
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(res.data.get('error'), "Invalid credentials")
+
+    def test_missing_access_token(self):
+        """
+        Test missing access token
+        """
+        res = self.social_login(self.social_url, self.missing_token)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data.get('errors').get('error')[0], "An access token is required for Social Login")
+
+    def test_missing_provider_field(self):
+        """
+        Test missing provider field
+        """
+        res = self.social_login(self.social_url, self.missing_provider)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data.get('errors').get('error')[0], "A provider is required for Social Login")
+
+    def test_missing_access_token_secret(self):
+        """
+        Test missing access token secret
+        """
+        res = self.social_login(self.social_url, self.missing_token_secret)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data.get('errors').get('error')[0], "An access token secret is required for Twitter Login")


### PR DESCRIPTION
#### Description
Currently, Users can login with their pre-existing social media accounts but the error messages are not descriptive. This fix returns messages that are more descriptive 

#### Type of change
- [x] Bug fix (nonbreaking change which fixes an issue)
- [ ] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [ ]  Integration test
- [x]  Unit test

#### Checklist:
- [x] My code follows the style guide for this project
- [ ] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Pivotal Tracker
[#165305757](https://www.pivotaltracker.com/story/show/165305757)

#### Screenshots
![image](https://user-images.githubusercontent.com/22356695/57198787-c2214200-6f7f-11e9-988c-493e730d6f42.png)
