### PR TITLE
#165812173 Redirect application root URL to swagger documentation 

### DIFF
--- a/authors/urls.py
+++ b/authors/urls.py
@@ -22,10 +22,10 @@ schema_view = get_swagger_view(title="The Immortals Api Swagger Docs")
 authurls = include(('authors.apps.authentication.urls',
                     'authentication'), namespace='authentication')
 profileurls = include(('authors.apps.profiles.urls',
-                    'profiles'), namespace='profile')
+                       'profiles'), namespace='profile')
 urlpatterns = [
     path('admin/', admin.site.urls),
     url(r'^api/', authurls),
-    url(r'^api/swagger/$', schema_view),
+    path('', schema_view),
     path('api/', profileurls),
 ]


### PR DESCRIPTION
### What does this PR do?
Redirects application root to swagger documentation
### What are the tasks to be completed?
* Ensure the `GET /` endpoint renders swagger documentation
### How can this be manually tested?
### Local Development Setup
 - First Create python virtual env
 ```
  $ virtualenv -p python .venv
 ```
 - Install Requirements
 ```
  $ pip install -r requiremts.txt
 ```
 - Copy .env-example to .env and set config
 ```
  $ cp .env-example .env
 ```
 - Create postgres database
 ```
 $ psql postgres
 postgres=# CREATE USER your-user WITH PASSWORD 'your-password';
 postgres=# ALTER ROLE your-user SET client_encoding TO 'utf8';
 postgres=# ALTER ROLE your-user SET default_transaction_isolation TO 'read committed';
 postgres=# ALTER ROLE your-user SET timezone TO 'UTC';
 postgres=# CREATE DATABASE your-database-name;
 postgres=# GRANT ALL PRIVILEGES ON DATABASE your-database-name TO your-user;
 postgres=# \q
````
a. **After cloning the repo:-**
```
$ git checkout  ch-redirectroot-to-swagger-165812173
$ python manage.py runserver
```
b. **Test Swagger**
1. Using a web browser, open the link `http://127.0.0.1:8000/`

### Screenshots
![image](https://user-images.githubusercontent.com/30015297/57238090-45e73700-7031-11e9-9cc4-d3f8ad250a40.png)

### What are the relevant pivotal tracker stories?
[#165812173](https://www.pivotaltracker.com/story/show/165812173)