### PR TITLE
#165812170 Integrate code climate to GitHub

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,8 @@
+version: "2"
+plugins:
+  pep8:
+    enabled: true
+exclude_patterns:
+  - "**/tests/"
+  - "**/migrations/"
+  - "**/tests.py"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/andela/ah-the-immortals-backend.svg?branch=develop)](https://travis-ci.org/andela/ah-the-immortals-backend)
 [![Coverage Status](https://coveralls.io/repos/github/andela/ah-the-immortals-backend/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-the-immortals-backend?branch=develop)
+[![Maintainability](https://api.codeclimate.com/v1/badges/a61d851f2a0c0e07d1ac/maintainability)](https://codeclimate.com/github/andela/ah-the-immortals-backend/maintainability)
 
 ## Vision
 


### PR DESCRIPTION
#### What does this PR do?
This pull request integrates code climate to GitHub so developers can view the quality of code and maintainability. 

#### Description of Task to be completed?
- Ensure that the code is formatted to PEP8 standards

#### How should this be manually tested?
- change branch to ch-code-climate-165812170 in GitHub and click on the `maintainability` badge to open code climate.

#### What are the relevant pivotal tracker stories?
- [165812170](https://www.pivotaltracker.com/story/show/165812170)

#### Screenshots
<img width="828" alt="Screenshot 2019-05-06 at 19 02 40" src="https://user-images.githubusercontent.com/45788436/57238220-8e9ef000-7031-11e9-9036-d825e87edd51.png">
