### PR TITLE
165879407Redirecting root to Swagger

### DIFF
--- a/authors/urls.py
+++ b/authors/urls.py
@@ -18,7 +18,6 @@ from django.urls import path
 from django.contrib import admin
 from rest_framework_swagger.views import get_swagger_view
 from django.views.generic.base import RedirectView
-from django.conf import settings
 
 schema_view = get_swagger_view(title="The Immortals Api Swagger Docs")
 authurls = include(('authors.apps.authentication.urls',
@@ -30,5 +29,5 @@ urlpatterns = [
     url(r'^api/', authurls),
     path('api/swagger/', schema_view),
     path('api/', profileurls),
-    path('', RedirectView.as_view(url=settings.DOMAIN+'/api/swagger/')),
+    path('', RedirectView.as_view(url='/api/swagger/')),
 ]


### PR DESCRIPTION
### What does this PR do?
Redirects application root to swagger documentation
### What are the tasks to be completed?
* Ensure the `GET /` endpoint Redirects a user to `GET /api/swagger/` i.e swagger documentation
### How can this be manually tested?

a. **After cloning the repo:-**
```
$ git checkout  bg-fix-swagger-redirection-165879407
$ python manage.py runserver
```
b. **Test Swagger**
1. Using a web browser, open the link `http://127.0.0.1:8000`

### Screenshots
![image](https://user-images.githubusercontent.com/30015297/57365505-dc306f80-718d-11e9-8185-83f9c7a1d212.png)
![image](https://user-images.githubusercontent.com/30015297/57365524-e3f01400-718d-11e9-9394-da0589b81688.png)

### What are the relevant pivotal tracker stories?
[#165879407](https://www.pivotaltracker.com/story/show/165879407)