### PR TITLE
#165940869 Add number of articles per page

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -84,6 +84,7 @@ class ArticlePaginator(PageNumberPagination):
 
     def get_paginated_response(self, data):
         return Response(OrderedDict([
+            ("pageCount", len(self.page.object_list)),
             ('articlesCount', self.page.paginator.count),
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),

--- a/authors/apps/articles/tests/basetests.py
+++ b/authors/apps/articles/tests/basetests.py
@@ -742,10 +742,6 @@ class PagniationBaseTest(APITestCase):
             format='json'
         )
         return response
-        return self.client.delete(self.modify_url)
-        self.user
-        return self.client.patch(self.modify_url, data=json.dumps(self.update),
-                                 content_type="application/json")
 
 
 class FilterBaseTest(TagsBaseTest):

--- a/authors/apps/articles/tests/test_pagination.py
+++ b/authors/apps/articles/tests/test_pagination.py
@@ -1,5 +1,6 @@
 from authors.apps.articles.tests.basetests import PagniationBaseTest
 from rest_framework import status
+from authors.apps.articles.models import Article
 
 
 class TestPagination(PagniationBaseTest):
@@ -122,4 +123,22 @@ class TestPagination(PagniationBaseTest):
         self.assertEqual(
             response.data.get("detail"),
             self.error_msg
+        )
+
+    def test_articles_per_page_count(self):
+        """
+        Tests return of the number of articles per page
+        """
+        response = self.get_articles_per_page(page_limit=4)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK
+        )
+        self.assertEqual(
+            response.data.get("pageCount"),
+            4
+        )
+        self.assertEqual(
+            response.data.get("articlesCount"),
+            Article.objects.all().count()
         )


### PR DESCRIPTION
### What does this PR do?
- Adds number of articles per page in paginated data
### What are the tasks to be completed?
* Ensure the endpoint for getting all articles has a count of the number of articles per page
### How can this be manually tested?
a. **After cloning the repo:-**
```
$ git checkout bg-add-articlescount-perpage-165940869
$ python manage.py runserver
```
b. **Test with postman**
1. After signing up a user and creating articles, using postman request:
```
GET http://127.0.0.1:8000/api/articles/
```
**Screenshots**
![image](https://user-images.githubusercontent.com/30015297/57544732-f40c1d00-7360-11e9-8580-6a3ca5767cff.png)
![image](https://user-images.githubusercontent.com/30015297/57544743-fbcbc180-7360-11e9-9b24-249551972fc9.png)

### What are the relevant pivotal tracker stories?
[#165940869](https://www.pivotaltracker.com/story/show/165940869)