### PR TITLE
#165952635 Fix Comment on articles

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -61,7 +61,7 @@ class ArticleSerializer(BaseSerializer):
         fields = (
             'slug', 'title', 'description', 'body', 'created_at',
             'updated_at', 'author', 'tagList', 'like', 'dislike',
-            'likesCount', 'dislikesCount'
+            'likesCount', 'dislikesCount', 'comments'
         )
 
 
@@ -163,6 +163,24 @@ class CommentSerializer(serializers.ModelSerializer):
         model = Comment
         fields = ('id', 'body', 'created_at',
                   'article', 'author', 'parent')
+
+
+class DisplayCommentsSerializer(serializers.ModelSerializer):
+    """
+    Serializer for rendering comments
+    """
+    class Meta:
+        model = Article
+        fields = ("comments",)
+
+
+class DisplaySingleComment(serializers.ModelSerializer):
+    """
+    Serializes single representation of any comment
+    """
+    class Meta:
+        model = Comment
+        fields = ("representation",)
 
 
 class CommentChildSerializer(serializers.ModelSerializer):

--- a/authors/apps/articles/tests/basetests.py
+++ b/authors/apps/articles/tests/basetests.py
@@ -86,6 +86,7 @@ class BaseTest(APITestCase):
         self.comment = {
             "body": "This is a test comment"
         }
+        self.maxDiff = None
 
     def login(self, email, password):
         """
@@ -537,6 +538,15 @@ class BaseTest(APITestCase):
         return self.client.delete(reverse(
             "articles:commentdetail", args=["this-is-mine", id]),
         )
+
+    def get_comment_by_id(self):
+        """if
+        update a comment
+        """
+        parent_comment = self.create_comment()
+        id = parent_comment.data['id']
+        return self.client.get(reverse(
+            "articles:commentdetail", args=["this-is-mine", id]))
 
 
 class TagsBaseTest(APITestCase):

--- a/authors/apps/articles/tests/test_comments.py
+++ b/authors/apps/articles/tests/test_comments.py
@@ -1,6 +1,9 @@
-from rest_framework import status
-from .basetests import BaseTest
 import json
+from rest_framework import status
+
+from authors.apps.articles.models import Comment
+
+from .basetests import BaseTest
 
 
 class TestComments(BaseTest):
@@ -13,6 +16,8 @@ class TestComments(BaseTest):
     msgg = 'unsuccesful update either the comment orslug not found'
     message = 'Comment deleted successfully'
     no_update = 'unsuccesful update either the comment orslug not found'
+    no_comment = 'no comments on this article'
+    no_comment_with_id = 'This article does not have a comment withthat id'
 
     def test_successful_comment_creation(self):
         """
@@ -90,7 +95,10 @@ class TestComments(BaseTest):
         Test one comment
         """
         response = self.get_all_comments()
+        comment = Comment.objects.all()[0]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get(
+            'comments')[0].get('body'), comment.body)
 
     def test_get_one_comment_not_found(self):
         """
@@ -98,11 +106,25 @@ class TestComments(BaseTest):
         """
         response = self.get_one_comment_not_found()
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.data["detail"], self.msg)
+        self.assertEqual(json.loads(response.content), {
+                         'comments': self.no_comment})
 
-    def test_successful_get_one_comment_by_id(self):
+    def test_unsuccessful_get_one_comment_by_id(self):
+        """
+        Test unsuccessful get one comment
+        """
+        response = self.get_comments_by_id()
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(json.loads(response.content), {
+                         'comments': self.no_comment_with_id})
+
+    def test_get_one_comment(self):
         """
         Test one comment
         """
-        response = self.get_comments_by_id()
+        response = self.get_comment_by_id()
+        comment = Comment.objects.all()[0]
+        # comment_id = comment.id
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get(
+            'comment').get('body'), comment.body)

--- a/authors/apps/articles/utils.py
+++ b/authors/apps/articles/utils.py
@@ -1,0 +1,19 @@
+def get_comments(comments):
+    parents = []
+    for comment in comments:
+        if comment.is_parent:
+            parents.append({
+                "id": comment.pk,
+                "createdAt": comment.created_at,
+                "updatedAt": comment.updated_at,
+                "body": comment.body,
+                "author": comment.get_profile_details(),
+                "replies": [{
+                    "id": child.pk,
+                    "createdAt": child.created_at,
+                    "updatedAt": child.updated_at,
+                    "body": child.body,
+                    "author": child.get_profile_details(),
+                } for child in comment.children()]
+            })
+    return parents


### PR DESCRIPTION
### What does this PR do?
- Nest the replies in the response data
### What are the tasks to be completed?
```
GET /api/articles/{slug}/comments/

```

* Fix that user can be able get to multiple and single comments where the replies are nested in the response data


### How can this be manually tested?
 **After cloning the repo:-**
**Test with postman**
Sign up a user, login, grub the token and add it to authorization:
```
$ git checkout  bg-comments-nesting-replies-165952635  
$ python manage.py runserver
```
**To run tests on terminal**
```
$ python manage.py test authors/apps/articles
```

### What are the relevant pivotal tracker stories?
[#165952635](https://www.pivotaltracker.com/n/projects/2326460/stories/165952635)

### Screenshots
<img width="1440" alt="Screenshot 2019-05-13 at 17 31 25" src="https://user-images.githubusercontent.com/17140636/57629913-4d648e00-75a5-11e9-9e2a-5c6fd8ae27cd.png">
<img width="1440" alt="Screenshot 2019-05-13 at 17 32 04" src="https://user-images.githubusercontent.com/17140636/57629932-58b7b980-75a5-11e9-84c0-29fbf2111f4d.png">
<img width="1440" alt="Screenshot 2019-05-13 at 17 33 20" src="https://user-images.githubusercontent.com/17140636/57629980-71c06a80-75a5-11e9-8e71-ffac19b63f73.png">
<img width="1440" alt="Screenshot 2019-05-13 at 17 33 34" src="https://user-images.githubusercontent.com/17140636/57629995-7a18a580-75a5-11e9-89c6-ae81c9e846d1.png">
<img width="1440" alt="Screenshot 2019-05-13 at 21 12 52" src="https://user-images.githubusercontent.com/17140636/57644050-ef936e80-75c3-11e9-9e98-0546451e57be.png">




