### PR TITLE
#165305770 Add Read-Time For an Article

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -11,6 +11,7 @@ import json
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from .utils import get_comments
+from authors.utils.article_timer import ArticleTimer
 
 User = get_user_model()
 
@@ -98,6 +99,11 @@ class Article(VoteModel, models.Model):
         """
         comments = Comment.objects.filter(article__slug=self.slug)
         return get_comments(comments)
+
+    @property
+    def readtime(self):
+        timer = ArticleTimer(self)
+        return timer.get_read_time()
 
 
 class Comment(models.Model):

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -70,7 +70,7 @@ class ArticleSerializer(BaseSerializer):
             'slug', 'title', 'description', 'body', 'created_at',
             'updated_at', 'author', 'tagList', 'like', 'dislike',
             'likesCount', 'dislikesCount', 'comments', 'favorite',
-            'favoritesCount'
+            'favoritesCount', 'readtime'
         )
 
 

--- a/authors/apps/articles/tests/test_article_read_time.py
+++ b/authors/apps/articles/tests/test_article_read_time.py
@@ -1,0 +1,79 @@
+from .basetests import BaseTest
+from rest_framework import status
+
+
+class TestReadTime(BaseTest):
+    """
+    Tests read time of an aerticle
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.new_article["body"] = self.word_generator(795)
+        self.minutes_time = "3 minutes"
+        self.seconds_time = "3 seconds"
+
+    def word_generator(self, num_words):
+        """
+        Generates a given number of words
+        """
+        words = ""
+        for i in range(num_words):
+            words += "random "
+        return words
+
+    def test_article_post_read_time(self):
+        """
+        Tests read time of an article during post 
+        """
+        response = self.create_article()
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED
+        )
+        self.assertEqual(
+            response.data.get("readtime"),
+            self.minutes_time
+        )
+
+    def test_article_update_read_time(self):
+        """
+        Tests read time of an article during an update
+        """
+        response = self.update_article()
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED
+        )
+        self.assertEqual(
+            response.data.get("article").get("readtime"),
+            self.seconds_time
+        )
+
+    def test_single_article_read_time(self):
+        """
+        Tests article read time for a single article
+        """
+        response = self.get_one_article()
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK
+        )
+        self.assertEqual(
+            response.data.get("article").get("readtime"),
+            self.seconds_time
+        )
+
+    def test_get_all_articles_read_time(self):
+        """
+        Test article read time on all articles
+        """
+        response = self.get_all_articles()
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK
+        )
+        self.assertEqual(
+            response.data.get("results").get("articles")[0].get("readtime"),
+            self.seconds_time
+        )

--- a/authors/utils/article_timer.py
+++ b/authors/utils/article_timer.py
@@ -1,0 +1,59 @@
+class ArticleTimer:
+    """
+    Read timer class for articles
+    """
+
+    def __init__(self, article):
+        self.article = article
+        self.words_per_minute = 265
+
+    def get_title(self):
+        """
+        Get title of article
+        """
+        return self.article.title
+
+    def get_body(self):
+        """
+        Gets body of the article
+        """
+        return self.article.body
+
+    def get_description(self):
+        """
+        Gets description of the article
+        """
+        return self.article.description
+
+    def get_tags(self):
+        """
+        Gets all words on a tag
+        """
+        tag_words = []
+        [tag_words.extend(tagword.split()) for tagword in self.article.tagList]
+        return tag_words
+
+    def get_article_info(self):
+        """
+        Gets the whole informnation of an article
+        """
+        info = []
+        info.extend(self.get_title().split())
+        info.extend(self.get_body().split())
+        info.extend(self.get_description().split())
+        info.extend(self.get_tags())
+        return info
+
+    def get_read_time(self):
+        """
+        Gets the read time of the article
+        """
+        word_length = len(self.get_article_info())
+        read_time = 0
+        if word_length:
+            timer = word_length/self.words_per_minute
+        if timer < 1:
+            read_time = str(round(timer*60))+" seconds"
+        else:
+            read_time = str(round(timer))+" minutes"
+        return read_time


### PR DESCRIPTION
### What does this PR do?
- Adds read time to articles
### What are the tasks to be completed?
- Ensure each article has an approximate read time
### How can this be manually tested?
a. **After cloning the repo:-**
```
$ git checkout  ft-read-time-165305770
$ python manage.py runserver
```
```
POST http://127.0.0.1:8000/api/articles/
```
2. Data
```
{
   "title": "How to train your dragon",
   "description": "Ever wonder how?",
   "body": "You have to believe",
   "tags":["names","Brian","test"]
}
```
3. Get request 
```
GET http://127.0.0.1:8000/api/articles/
```
### Screenshots
![image](https://user-images.githubusercontent.com/30015297/57650714-15c10a80-75d4-11e9-8ba3-ee26215fe958.png)
![image](https://user-images.githubusercontent.com/30015297/57650720-19549180-75d4-11e9-877d-553606497c08.png)
![image](https://user-images.githubusercontent.com/30015297/57650729-1ce81880-75d4-11e9-81fc-859c753e451d.png)
![image](https://user-images.githubusercontent.com/30015297/57650737-207b9f80-75d4-11e9-8aee-fc9476f48814.png)

### What are the relevant pivotal tracker stories?
[#165305770](https://www.pivotaltracker.com/story/show/165305770)