### PR TITLE
#166000116 Fix parent info on the comments

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -120,9 +120,6 @@ class Comment(models.Model):
     class Meta:
         ordering = ['-created_at']
 
-    # def __str__(self):
-    #     return self.body
-
     def children(self):
         return Comment.objects.filter(parent=self)
 
@@ -139,7 +136,9 @@ class Comment(models.Model):
         """
         Representation of a comment in a JSON serializable format
         """
-
+        parent = self.parent
+        if self.parent:
+            parent = self.parent.pk
         response = {
             "id": self.pk,
             "article": {
@@ -149,7 +148,8 @@ class Comment(models.Model):
             "createdAt": self.created_at,
             "updatedAt": self.updated_at,
             "body": self.body,
-            "author": self.get_profile_details()
+            "author": self.get_profile_details(),
+            "parent": parent
         }
         return response
 

--- a/authors/apps/articles/tests/test_comments.py
+++ b/authors/apps/articles/tests/test_comments.py
@@ -17,7 +17,7 @@ class TestComments(BaseTest):
     message = 'Comment deleted successfully'
     no_update = 'unsuccesful update either the comment orslug not found'
     no_comment = 'no comments on this article'
-    no_comment_with_id = 'This article does not have a comment withthat id'
+    no_comment_with_id = 'This article does not have a comment with that id'
 
     def test_successful_comment_creation(self):
         """
@@ -124,7 +124,7 @@ class TestComments(BaseTest):
         """
         response = self.get_comment_by_id()
         comment = Comment.objects.all()[0]
-        # comment_id = comment.id
+        comment_id = comment.id
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get(
-            'comment').get('body'), comment.body)
+        self.assertEqual(response.data['comment']['body'], comment.body)
+        self.assertEqual(response.data['comment']['parent'], None)

--- a/authors/apps/articles/utils.py
+++ b/authors/apps/articles/utils.py
@@ -8,12 +8,14 @@ def get_comments(comments):
                 "updatedAt": comment.updated_at,
                 "body": comment.body,
                 "author": comment.get_profile_details(),
+                "parent": comment.parent,
                 "replies": [{
                     "id": child.pk,
                     "createdAt": child.created_at,
                     "updatedAt": child.updated_at,
                     "body": child.body,
                     "author": child.get_profile_details(),
+                    "parent_id": comment.pk
                 } for child in comment.children()]
             })
     return parents

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -55,7 +55,7 @@ def get_serialiser_data(serializer_data, content):
             response = Response(
                 data={
                     "comments": "This article does not have a comment with"
-                    "that id"
+                    " that id"
                 },
                 status=status.HTTP_404_NOT_FOUND
             )


### PR DESCRIPTION
### What does this PR do?
- Fixes the error message 
- Adds parent information on the comments
### What are the tasks to be completed?
```
GET /api/articles/{slug}/comments/
GET /api/articles/{slug}/comments/id/

```

* Fix that user can be able get to multiple and single comments where the response data and message are properly fixed.


### How can this be manually tested?
 **After cloning the repo:-**
**Test with postman**
Sign up a user, login, grub the token and add it to authorization:
```
$ git checkout  bg-fix-parent-comment-info-166000116  
$ python manage.py runserver
```
**To run tests on terminal**
```
$ python manage.py test authors/apps/articles
```

### What are the relevant pivotal tracker stories?
[#166000116](https://www.pivotaltracker.com/n/projects/2326460/stories/166000116)

### Screenshots
<img width="1440" alt="Screenshot 2019-05-14 at 16 59 43" src="https://user-images.githubusercontent.com/17140636/57703940-b1e92100-7669-11e9-9e22-89833faf9d37.png">
<img width="1440" alt="Screenshot 2019-05-14 at 16 58 46" src="https://user-images.githubusercontent.com/17140636/57703993-c88f7800-7669-11e9-8b83-04faa3a0893d.png">
