### PR TITLE
#165305775 Comments should be able to track edit history

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -13,6 +13,7 @@ from django.dispatch import receiver
 from .utils import get_comments
 from authors.utils.article_timer import ArticleTimer
 
+
 User = get_user_model()
 
 
@@ -129,7 +130,7 @@ class Comment(models.Model):
     parent = models.ForeignKey(
         'self', null=True, blank=True, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         ordering = ['-created_at']
@@ -247,3 +248,12 @@ class RatingModel(models.Model):
                 "average_ratings": Article().average_ratings(article)
             }
         return 0
+
+
+class CommentHistory(models.Model):
+    """
+    A class model for saving history comments by id
+    """
+    commentId = models.ForeignKey(Comment, on_delete=models.CASCADE)
+    body = models.TextField(null=False, blank=False)
+    created_at = models.DateTimeField(auto_now_add=True)

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -9,7 +9,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from .exceptions import ArticleNotFound
-from .models import Article, Comment, Favorite, RatingModel
+from .models import Article, Comment, Favorite, RatingModel, CommentHistory
 
 
 class ArticleSerializer(BaseSerializer):
@@ -197,16 +197,20 @@ class CommentChildSerializer(serializers.ModelSerializer):
         fields = ('id', 'body', 'created_at', 'author', 'parent')
 
 
-class CommentDetailSerializer(serializers.ModelSerializer):
+class CommentDetailSerializer(BaseSerializer):
     """
     Comments with replies serializer
     """
+
+    def __init__(self, *args, **kwargs):
+        super(CommentDetailSerializer, self).__init__(*args, **kwargs)
+
     replies = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
         fields = ('id', 'author', 'body', 'article',
-                  'created_at', 'replies', 'parent')
+                  'created_at', 'updated_at', 'replies', 'parent',)
 
     @staticmethod
     def get_replies(obj):
@@ -216,3 +220,20 @@ class CommentDetailSerializer(serializers.ModelSerializer):
         if obj.is_parent:
             return CommentChildSerializer(obj.children(), many=True).data
         return None
+
+
+class CommentEditHistorySerializer(BaseSerializer):
+    """
+    A class serializer for comments history
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(CommentEditHistorySerializer, self).__init__(*args, **kwargs)
+
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+
+    class Meta:
+        model = CommentHistory
+        fields = (
+            'id', 'body', 'created_at'
+        )

--- a/authors/apps/articles/tests/basetests.py
+++ b/authors/apps/articles/tests/basetests.py
@@ -5,7 +5,7 @@ from rest_framework.test import APITestCase, APIClient
 from rest_framework.reverse import reverse
 from rest_framework.authtoken.models import Token
 import json
-from authors.apps.articles.models import Article, Tag, Comment
+from authors.apps.articles.models import Article, Tag, Comment, CommentHistory
 from django.conf import settings
 from authors.apps.articles.filters import ArticleFilter
 
@@ -69,6 +69,12 @@ class BaseTest(APITestCase):
             body='this is a test body'
         )
         self.comment.save()
+        self.comment_hist = Comment.objects.create(
+            article=self.article,
+            author=self.user1,
+            body='This is a test history comment'
+        )
+        self.comment_hist.save()
         self.update = {
             "description": "Brian Koin is making noise"
         }
@@ -527,7 +533,7 @@ class BaseTest(APITestCase):
         return self.client.put(commentsdetail_url_delete,
                                data=json.dumps(self.update_comment),
                                content_type="application/json")
-
+    
     def update_comment_succefully(self):
         """if
         update a comment
@@ -538,6 +544,84 @@ class BaseTest(APITestCase):
             "articles:commentdetail", args=["this-is-mine", id]),
             data=json.dumps(self.update_comment),
             content_type="application/json")
+    
+    def create_comment_history(self):
+        """
+        Create a new comment
+        """
+        return self.client.post(self.comments_url,
+                                data=json.dumps(self.new_comment),
+                                content_type="application/json")
+
+    def get_comment_for_history(self):
+        """
+        A method to get all user favorite articles
+        """
+        comment_id = str(self.comment_hist.id)
+        slug = str(self.article.slug)
+        url = reverse("articles:commentdetail", args=[slug, comment_id])
+        return self.client.get(
+            url,
+            content_type="application/json"
+        )
+
+    def update_comment_exist_in_history(self, body):
+        comment_id = str(self.comment_hist.id)
+        slug = str(self.article.slug)
+        url = reverse("articles:commentdetail", args=[slug, comment_id])
+        return self.client.put(
+            url,
+            data=json.dumps(
+                {
+                    "body": body
+                }
+            ),
+            content_type="application/json"
+        )
+
+    def delete_comment_for_history(self):
+        comment_id = str(self.comment_hist.id)
+        slug = str(self.article.slug)
+        url = reverse("articles:commentdetail", args=[slug, comment_id])
+        return self.client.delete(
+            url,
+            content_type="application/json"
+        )
+    
+    def get_one_comment_history(self):
+        comment_id = str(self.comment_hist.id)
+        slug = str(self.article.slug)
+        url = reverse("articles:history_", args=[slug, comment_id, 1])
+        return self.client.get(
+            url,
+            content_type="application/json"
+        )
+
+    def get_one_comment_history_not_found(self):
+        comment_id = str(self.comment_hist.id)
+        slug = str(self.article.slug)
+        url = reverse("articles:history_", args=[slug, comment_id, 10])
+        return self.client.get(
+            url,
+            content_type="application/json"
+        )
+
+    def get_all_comment_history(self):
+        comment_id = str(self.comment_hist.id)
+        slug = str(self.article.slug)
+        url = reverse("articles:history_comments", args=[slug, comment_id])
+        return self.client.get(
+            url,
+            content_type="application/json"
+        )
+
+    def get_all_comment_history_not_found(self):
+        slug = str(self.article.slug)
+        url = reverse("articles:history_comments", args=[slug, 234])
+        return self.client.get(
+            url,
+            content_type="application/json"
+        )
 
     def delete_comment_succefully(self):
         """if

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -4,7 +4,8 @@ from django.urls import path, re_path
 from .views import (CommentAPIView, CommentDetailAPIView, FavoritesView,
                     FetchTags, LikeDislikeView, ListCreateArticleAPIView,
                     ListUserFavoriteArticlesView, RateArticleAPIView,
-                    RetrieveUpdateArticleAPIView, SocialShareArticleView)
+                    RetrieveUpdateArticleAPIView, SocialShareArticleView,
+                    CommentOneHistoryView, CommentAllHistoryView)
 
 
 app_name = 'articles'
@@ -14,7 +15,7 @@ urlpatterns = [
     path('tags/', FetchTags.as_view(), name="all_tags"),
     path('articles/<slug>/comments/',
          CommentAPIView.as_view(), name='comment'),
-    path('articles/<slug>/comments/<id>/',
+    path('articles/<slug>/comments/<int:id>/',
          CommentDetailAPIView.as_view(), name='commentdetail'),
     path('articles/<slug>/', RetrieveUpdateArticleAPIView.as_view(),
          name='articles'),
@@ -28,4 +29,8 @@ urlpatterns = [
          RateArticleAPIView.as_view(), name='rating_articles'),
     path("articles/<slug>/share/<provider>/",
          SocialShareArticleView.as_view(), name="share"),
+    path('articles/<slug>/comments/<int:comment>/history/<int:id>/',
+         CommentOneHistoryView.as_view(), name='history_'),
+    path('articles/<slug>/comments/<int:comment>/history/',
+         CommentAllHistoryView.as_view(), name='history_comments'),
 ]


### PR DESCRIPTION
### What does this PR do?
- Implement Edit history comments
### What are the tasks to be completed?
* Update comment and confirm that the previous comment is saved in the history
* Write tests for the implementation
### How can this be manually tested?
### Local Development Setup
Refer to the project Readme.md for this.
**Test with postman**
1. Signing up a user and verify and authenticate
2. Create an article and comment on it:
3. Run the endpoints for Updating a comment and getting a comment
```
PUT http://127.0.0.1:8000/api/articles/{article-slug}/comments/{comment-id}
GET http://127.0.0.1:8000/api/articles/{article-slug}/comments/{comment-id}/history/{history-id}/
GET http://127.0.0.1:8000/api/articles/{article-slug}/comments/{comment-id}/history/
```

**Run Tests**
```python manage.py test
```

**Screenshots**
<img width="1114" alt="Screenshot 2019-05-15 at 16 21 52" src="https://user-images.githubusercontent.com/45788436/57830644-634b9c00-77bb-11e9-9e7a-a290b5c88873.png">
<img width="1125" alt="Screenshot 2019-05-16 at 09 10 52" src="https://user-images.githubusercontent.com/45788436/57830645-634b9c00-77bb-11e9-8a43-4538cff1821b.png">
<img width="1128" alt="Screenshot 2019-05-16 at 09 15 31" src="https://user-images.githubusercontent.com/45788436/57830646-634b9c00-77bb-11e9-934f-866176614df9.png">


### What are the relevant pivotal tracker stories?
[#165305775](https://www.pivotaltracker.com/n/projects/2326460/stories/165305775)