### PR TITLE
#166027202 User can delete a specific notification

### DIFF
--- a/authors/apps/appnotifications/tests/basetest.py
+++ b/authors/apps/appnotifications/tests/basetest.py
@@ -11,6 +11,8 @@ class NotificationBaseTest(BaseTest):
     notification_url = reverse("notifications:all-notifications")
     unread_notification_url = reverse("notifications:unread-notifications")
     subscribe_unsubscribe_url = reverse("notifications:subscription")
+    delete_single_url = reverse("notifications:deleteone", args=[2])
+    delete_single_invalid_id = reverse("notifications:deleteone", args=[56])
 
     def follow_user(self):
         self.is_authenticated("jim@gmail.com", "@Us3r.com")

--- a/authors/apps/appnotifications/tests/test_notifications.py
+++ b/authors/apps/appnotifications/tests/test_notifications.py
@@ -92,3 +92,27 @@ class TestNotifications(NotificationBaseTest):
         response = self.client.delete(self.notification_url)
         self.assertEqual(response.data['message'], 'No notifications found')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_one_notifications_successfully(self):
+        """
+        Test deletion of a single notification
+        """
+        self.follow_user()
+        self.create_article()
+        self.is_authenticated("jim@gmail.com", "@Us3r.com")
+        response = self.client.delete(self.delete_single_url)
+        self.assertEqual(response.data['message'],
+                         'Notification deleted successfully')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_one_notifications_unsuccessfully(self):
+        """
+        Test deletion of a single notification provided invalid id
+        """
+        self.follow_user()
+        self.create_article()
+        self.is_authenticated("jim@gmail.com", "@Us3r.com")
+        response = self.client.delete(self.delete_single_invalid_id)
+        self.assertEqual(response.data['message'],
+                         'No notification found with that id')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/apps/appnotifications/urls.py
+++ b/authors/apps/appnotifications/urls.py
@@ -8,20 +8,25 @@ urlpatterns = [
         'notifications/',
         views.AllNotificationsAPIview.as_view(),
         name="all-notifications"
-        ),
+    ),
     path(
         'notifications/unread/',
         views.UnreadNotificationsAPIview.as_view(),
         name="unread-notifications"
-        ),
+    ),
     path(
         'notifications/subscription/',
         views.SubscribeUnsubscribeAPIView.as_view(),
         name="subscription"
-        ),
+    ),
     path(
         'notifications/unsubscribe_email/<str:token>/',
         views.UnsubscribeEmailAPIView.as_view(),
         name="opt_out_link"
+    ),
+    path(
+        'notifications/<id>/',
+        views.DeleteSingleNotificationAPIView.as_view(),
+        name="deleteone"
     )
 ]

--- a/authors/apps/appnotifications/views.py
+++ b/authors/apps/appnotifications/views.py
@@ -102,3 +102,23 @@ class UnreadNotificationsAPIview(NotificationApiView):
     def notifications(self, request):
         request.user.notifications.unread()
         return request.user.notifications.active()
+
+
+class DeleteSingleNotificationAPIView(NotificationApiView):
+    """
+    delete a single notification
+    """
+
+    def delete(self, request, *args, **kwargs):
+        try:
+            notif = request.user.notifications.active().get(id=kwargs['id'])
+            notif.deleted = True
+            notif.save()
+            resp = {
+                'message': 'Notification deleted successfully'
+            }
+        except Exception:
+            resp = {
+                'message': 'No notification found with that id'
+            }
+        return Response(resp)

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -137,13 +137,6 @@ AUTHENTICATION_BACKENDS = (
     'social_core.backends.twitter.TwitterOAuth',
     'django.contrib.auth.backends.ModelBackend',
 )
-# email settings
-EMAIL_BACKEND = os.getenv('EMAIL_BACKEND')
-EMAIL_HOST = os.getenv('EMAIL_HOST')
-EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
-EMAIL_PORT = os.getenv('EMAIL_PORT')
-EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
-EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS')
 
 DOMAIN = os.getenv("DOMAIN")
 VERIFICATION_URL = DOMAIN+'/api/users/activate/'

--- a/authors/utils/notification_handlers.py
+++ b/authors/utils/notification_handlers.py
@@ -98,7 +98,7 @@ def email_notification_handler(user, description):
     send_mail(
         "User Notification",
         '',
-        settings.EMAIL_HOST_USER,
+        settings.DEFAULT_EMAIL,
         [user.user.email],
         html_message=html_content)
 


### PR DESCRIPTION
### What does this PR do?
- Implement deletion of a specific notification
### What are the tasks to be completed?
* Create endpoint to enable user to delete a single notification
* Write tests for the implementation
### How can this be manually tested?
### Local Development Setup
Refer to the project [Readme.md](https://github.com/andela/ah-the-immortals-backend) for this.
**Test with postman**
1. Signing up two users and verify
2. Follow one user: 
```
POST  http://127.0.0.1:8000/api/profiles/<*username*>/follow/
```
3. Create an article using the followed user:
```
POST http://127.0.0.1:8000/api/articles/
```
4. Fetch the following-user notifications using:
```
GET http://127.0.0.1:8000/api/notifications/
```
5. Send a delete request to the following url using the correct parameters with the following-user:
```
DELETE **http://127.0.0.1:8000/api/notifications/<*id*>/
```
**Screenshots**
![image](https://user-images.githubusercontent.com/41931013/57764710-abf84c00-770c-11e9-8e3e-aec357bbed2a.png)
![image](https://user-images.githubusercontent.com/41931013/57764740-badefe80-770c-11e9-8047-9e501554f9fc.png)

### What are the relevant pivotal tracker stories?
[##166027202](https://www.pivotaltracker.com/n/projects/2326460/stories/166027202)