### PR TITLE
#166028283 Fix email verification During signup

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -5,10 +5,10 @@ from .models import User
 from django.core.validators import EmailValidator
 from django.core.exceptions import ValidationError
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import timezone
 from rest_framework.authtoken.models import Token
 from django.contrib.auth.password_validation import validate_password
 from authors.utils.password_validators import get_password_policy_errors
+from authors.utils.authentication_handlers import AuthTokenHandler
 
 
 class RegistrationSerializer(serializers.ModelSerializer):
@@ -300,7 +300,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
             raise serializers.ValidationError({
                 "token": "Invalid token"
             })
-        if self.expired_token(token_object):
+        if AuthTokenHandler.expired_token(token_object):
             raise serializers.ValidationError({
                 "token": "Expired token"
             })
@@ -340,12 +340,3 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
             raise serializers.ValidationError({
                 "password": "Passwords did not match"
             })
-
-    def expired_token(self, auth_token):
-        """
-        Checks expiry of token
-        """
-        utc_now = timezone.now()
-        expired = auth_token.created < utc_now - \
-            timezone.timedelta(hours=24)
-        return expired

--- a/authors/apps/authentication/tests/basetests.py
+++ b/authors/apps/authentication/tests/basetests.py
@@ -185,6 +185,29 @@ class BaseTest(APITestCase):
         user.is_verified = True
         user.save()
 
+    def generate_expired_auth_token(self):
+        """
+        Generates expired auth token
+        """
+        token = self.generate_auth_token()
+        token.created = timezone.now()-timezone.timedelta(hours=25)
+        token.save()
+        return token
+
+    def generate_auth_token(self):
+        """
+        Generates auth token
+        """
+        token, created = Token.objects.get_or_create(user=self.user)
+        return token
+
+    def generate_fake_auth_token(self):
+        """
+        Generates fake authentication token
+        """
+        token = "fjeojfoeefubbfbwuebbyvyfvwd24"
+        return token
+
 
 class PasswordResetBaseTest(BaseTest):
     """
@@ -218,7 +241,7 @@ class PasswordResetBaseTest(BaseTest):
             data=self.reset_data,
             format="json"
         )
-        token, created = Token.objects.get_or_create(user=self.user)
+        token = self.generate_auth_token()
         self.token = token.key
         self.set_password_confirm_url()
         return response
@@ -227,16 +250,14 @@ class PasswordResetBaseTest(BaseTest):
         """
         Generates invalid token
         """
-        self.token = "fjeojfoeefubbfbwuebbyvyfvwd24"
+        self.token = self.generate_fake_auth_token()
         self.set_password_confirm_url()
 
     def generate_expired_token(self):
         """
         Generates expired token
         """
-        token, created = Token.objects.get_or_create(user=self.user)
-        token.created = timezone.now()-timezone.timedelta(hours=25)
-        token.save()
+        token = self.generate_expired_auth_token()
         self.token = token.key
         self.set_password_confirm_url()
 

--- a/authors/apps/authentication/tests/test_verify_user.py
+++ b/authors/apps/authentication/tests/test_verify_user.py
@@ -7,41 +7,44 @@ class TestUserVerification(BaseTest):
     This class handles the testing of User Verification
     """
 
-    def test_successfull_verification(self):
-        token = self.generate_jwt_token('pablo@escobar.com', 'Escobar')
-        url = self.verification_of_user + token
+    def setUp(self):
+        super().setUp()
+        self.user.is_verified = False
+        self.user.save()
 
+    def verify(self, token):
+        """
+        Verifies a user
+        """
+        url = self.verification_of_user + token
         response = self.client.get(url)
+        return response
+
+    def test_successfull_verification(self):
+        token = self.generate_auth_token().key
+        response = self.verify(token)
         self.assertEqual(response.data['message'],
                          "You have been verified successfully")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_invalid_verification_token(self):
-        self.signup_user('Elchapo', 'el@chapo.com', 'Maina9176')
-        self.verify_user('el@chapo.com')
-        token = self.generate_jwt_token('el@chapo.com', 'Elchapo')
-        url = self.verification_of_user + token
-
-        response = self.client.get(url)
-
+    def test_used_verification_token(self):
+        token = self.generate_auth_token().key
+        self.verify(token)
+        response = self.verify(token)
         self.assertEqual(response.data['message'],
                          "Your email is already verified")
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
     def test_invalid_verification_token(self):
-        token = "sidvfldifhsv"
-        url = self.verification_of_user + token
-
-        response = self.client.get(url)
+        token = self.generate_fake_auth_token()
+        response = self.verify(token)
         self.assertEqual(
             response.data['detail'], "Invalid Token. The token provided cannot be decoded!")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_expired_jwt_token(self):
-        token = self.generate_expired_token()
-        url = self.verification_of_user + token
-
-        response = self.client.get(url)
+    def test_expired_auth_token(self):
+        token = self.generate_expired_auth_token().key
+        response = self.verify(token)
         self.assertEqual(
             response.data['detail'],
             'The token used has expired. Please authenticate again!')

--- a/authors/templates/mail.html
+++ b/authors/templates/mail.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Confirm your account</title>
+  <title>Authors Heaven Email Veification</title>
   <style type="text/css" rel="stylesheet" media="all">
     /* Base ------------------------------ */
     *:not(br):not(tr):not(html) {
@@ -16,12 +16,12 @@
       height: 100%;
       margin: 0;
       line-height: 1.4;
-      background-color: white;
-      color: black;
+      background-color:white;
+      color:black;
       -webkit-text-size-adjust: none;
     }
     a {
-      color: #414EF9;
+      color: white;
     }
 
     /* Layout ------------------------------ */
@@ -94,7 +94,9 @@
     .align-right {
       text-align: right;
     }
-
+    .white-section a{
+      color: white;
+    }
     /* Type ------------------------------ */
     h1 {
       margin-top: 0;
@@ -119,7 +121,7 @@
     }
     p {
       margin-top: 0;
-      color: black;
+      color:black;
       font-size: 16px;
       line-height: 1.5em;
       text-align: left;
@@ -135,7 +137,7 @@
     .button {
       display: inline-block;
       width: 200px;
-      background-color: #414EF9;
+      background-color:white;
       border-radius: 3px;
       color: #ffffff;
       font-size: 15px;
@@ -149,10 +151,10 @@
       background-color: #28DB67;
     }
     .button--red {
-      background-color: rgb(226, 173, 185);
+      background-color:red;
     }
     .button--blue {
-      background-color: dodgerblue;
+      background-color:dodgerblue;
     }
 
     /*Media Queries ------------------------------ */
@@ -177,7 +179,7 @@
           <!-- Logo -->
           <tr>
             <td class="email-masthead">
-              <a class="email-masthead_name">Authors Haven</a>
+              <a class="email-masthead_name">Authors Heaven</a>
             </td>
           </tr>
           <!-- Email Body -->
@@ -187,28 +189,33 @@
                 <!-- Body content -->
                 <tr>
                   <td class="content-cell">
-                      <h1>Hi {{name}},</h1>
-                    <p>We need to make sure you're you!</p>
-                    <p>So we need to confirm the email address before we activate your account. </p>
+                    <h1>Hey {{name}},</h1>
+                    <p>You are almost ready to start enjoying Authors Heaven.</p>
+                    <p>Simply click the big blue button below to verify your email address</p>
                     <!-- Action -->
                     <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
                       <tr>
                         <td align="center">
-                          <div>
-                            <a id="Link" href="{{ verification }}" class="button button--blue">Verify Email</a>
+                          <div class="white-section">
+                            <!--[if mso]><v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{verification}}" style="height:45px;v-text-anchor:middle;width:200px;" arcsize="7%" stroke="f" fill="t">
+                              <v:fill type="tile" color="#FF3665" />
+                              <w:anchorlock/>
+                              <center style="color:#ffffff;font-family:sans-serif;font-size:15px;">Reset your password</center>
+                            </v:roundrect><![endif]-->
+                            <a href="{{verification}}" class="button button--blue white-link">Verify email address</a>
                           </div>
                         </td>
                       </tr>
                     </table>
-                    <p>Thanks for creating an account with us. </p>
-
+                    <p>This verification is only valid for the next 24 hours, so be sure to use it right away.</p>
+                    <p>Thanks,<br>Authors Heaven team</p>
+                    <p><strong>P.S.</strong> We also love hearing from you and helping you with any issues you have. Please reach out to us if you want to ask a question or just say hi.</p>
                     <!-- Sub copy -->
                     <table class="body-sub">
                       <tr>
                         <td>
-                          <p class="sub">
-                                This message was sent to {{ name }}. If you have questions or complaints, please contact us.
-                          </p>
+                          <p class="sub">If you’re having trouble clicking the verification button, copy and paste the URL below into your web browser.</p>
+                          <p class="sub"><a href="{{verification}}">{{verification}}</a></p>
                         </td>
                       </tr>
                     </table>
@@ -224,8 +231,9 @@
                   <td class="content-cell">
                     <p class="sub center">&copy; 2019 Authors Heaven. All rights reserved.</p>
                     <p class="sub center">
-                      Authors Haven.
-                      <br>Andela Kenya , off USIU road
+                      Authors Heaven
+                      <br>{{product_address_line1}}
+                      <br>{{product_address_line2}}
                     </p>
                   </td>
                 </tr>

--- a/authors/utils/authentication_handlers.py
+++ b/authors/utils/authentication_handlers.py
@@ -1,0 +1,28 @@
+from django.utils import timezone
+from rest_framework.authtoken.models import Token
+
+
+class AuthTokenHandler:
+    """
+    Handles variations in auth token
+    """
+    @staticmethod
+    def expired_token(auth_token):
+        """
+        Checks expiry of auth token
+        """
+        utc_now = timezone.now()
+        expired = auth_token.created < utc_now - \
+            timezone.timedelta(hours=24)
+        return expired
+
+    @staticmethod
+    def create_auth_token(user):
+        """
+        Creates an auth token for a user
+        """
+        token, created = Token.objects.get_or_create(user=user)
+        if not created:
+            token.created = timezone.now()
+            token.save()
+        return token


### PR DESCRIPTION
### What does this PR do?
- Verifies user using authtoken instead of jwt token returned during signup
- Updates html teamplate used for account verification
### What are the tasks to be completed?
* Ensure a client cannot be verified with the jwt token returned during signup
* Ensure the email sent from Authors Heaven is standard on matters template design
### How can this be manually tested?
a. **After cloning the repo:-**
```
$ git checkout bg-fix-signup-verification-166028283
$ python manage.py runserver
```
b. **Test with postman**
1. After signing up a user and creating articles, using postman request:

**Signup**
```
POST http://127.0.0.1:8000/api/user/
{
	"email":"your email address",
	"username":"your username",
	"password":"Your password"
}

```
**Screenshots**
![image](https://user-images.githubusercontent.com/30015297/57795037-b0912480-774d-11e9-8e5d-77b2f64ef875.png)
![image](https://user-images.githubusercontent.com/30015297/57795055-b8e95f80-774d-11e9-9ca1-7c8c2bb5ca8c.png)
![image](https://user-images.githubusercontent.com/30015297/57795068-c30b5e00-774d-11e9-800d-aa9e57b75cf6.png)

### What are the relevant pivotal tracker stories?
[#166028283](https://www.pivotaltracker.com/story/show/166028283)