### PR TITLE
#166044739 Fix likes|dislikes and favorites

### DIFF
--- a/authors/apps/appnotifications/tests/basetest.py
+++ b/authors/apps/appnotifications/tests/basetest.py
@@ -11,6 +11,8 @@ class NotificationBaseTest(BaseTest):
     notification_url = reverse("notifications:all-notifications")
     unread_notification_url = reverse("notifications:unread-notifications")
     subscribe_unsubscribe_url = reverse("notifications:subscription")
+    delete_single_url = reverse("notifications:deleteone", args=[2])
+    delete_single_invalid_id = reverse("notifications:deleteone", args=[56])
 
     def follow_user(self):
         self.is_authenticated("jim@gmail.com", "@Us3r.com")

--- a/authors/apps/appnotifications/tests/test_notifications.py
+++ b/authors/apps/appnotifications/tests/test_notifications.py
@@ -92,3 +92,27 @@ class TestNotifications(NotificationBaseTest):
         response = self.client.delete(self.notification_url)
         self.assertEqual(response.data['message'], 'No notifications found')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_one_notifications_successfully(self):
+        """
+        Test deletion of a single notification
+        """
+        self.follow_user()
+        self.create_article()
+        self.is_authenticated("jim@gmail.com", "@Us3r.com")
+        response = self.client.delete(self.delete_single_url)
+        self.assertEqual(response.data['message'],
+                         'Notification deleted successfully')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_one_notifications_unsuccessfully(self):
+        """
+        Test deletion of a single notification provided invalid id
+        """
+        self.follow_user()
+        self.create_article()
+        self.is_authenticated("jim@gmail.com", "@Us3r.com")
+        response = self.client.delete(self.delete_single_invalid_id)
+        self.assertEqual(response.data['message'],
+                         'No notification found with that id')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/apps/appnotifications/urls.py
+++ b/authors/apps/appnotifications/urls.py
@@ -8,20 +8,25 @@ urlpatterns = [
         'notifications/',
         views.AllNotificationsAPIview.as_view(),
         name="all-notifications"
-        ),
+    ),
     path(
         'notifications/unread/',
         views.UnreadNotificationsAPIview.as_view(),
         name="unread-notifications"
-        ),
+    ),
     path(
         'notifications/subscription/',
         views.SubscribeUnsubscribeAPIView.as_view(),
         name="subscription"
-        ),
+    ),
     path(
         'notifications/unsubscribe_email/<str:token>/',
         views.UnsubscribeEmailAPIView.as_view(),
         name="opt_out_link"
+    ),
+    path(
+        'notifications/<id>/',
+        views.DeleteSingleNotificationAPIView.as_view(),
+        name="deleteone"
     )
 ]

--- a/authors/apps/appnotifications/views.py
+++ b/authors/apps/appnotifications/views.py
@@ -102,3 +102,23 @@ class UnreadNotificationsAPIview(NotificationApiView):
     def notifications(self, request):
         request.user.notifications.unread()
         return request.user.notifications.active()
+
+
+class DeleteSingleNotificationAPIView(NotificationApiView):
+    """
+    delete a single notification
+    """
+
+    def delete(self, request, *args, **kwargs):
+        try:
+            notif = request.user.notifications.active().get(id=kwargs['id'])
+            notif.deleted = True
+            notif.save()
+            resp = {
+                'message': 'Notification deleted successfully'
+            }
+        except Exception:
+            resp = {
+                'message': 'No notification found with that id'
+            }
+        return Response(resp)

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -21,6 +21,8 @@ class ArticleSerializer(BaseSerializer):
         super(ArticleSerializer, self).__init__(*args, **kwargs)
 
     author = serializers.ReadOnlyField(source="get_author_details")
+    like_info = serializers.SerializerMethodField()
+    favorites = serializers.SerializerMethodField()
 
     def get_user_article(self):
         request = self.context.get('request', None)
@@ -52,6 +54,14 @@ class ArticleSerializer(BaseSerializer):
         like = self.get_likes(1)
         return like
 
+    def get_likes_count(self, obj):
+        article = self.get_likes_data()
+        return article.votes.count()
+
+    def get_dislikes_count(self, obj):
+        article = self.get_likes_data()
+        return article.votes.count(1)
+
     def get_favorite(self, instance):
         user, article = self.get_user_article()
         is_favorited = Favorite().is_favorited(user, article)
@@ -63,20 +73,32 @@ class ArticleSerializer(BaseSerializer):
         ratings = RatingModel().ratings(article.id, request.user.id)
         return ratings
 
-    like = serializers.SerializerMethodField()
-    dislike = serializers.SerializerMethodField()
-    favorite = serializers.SerializerMethodField()
-    likesCount = serializers.ReadOnlyField(source='num_vote_up')
-    dislikesCount = serializers.ReadOnlyField(source='num_vote_down')
+    def get_like_info(self, obj):
+        mapped_data = {
+            "like": self.get_like(self),
+            "dislike": self.get_dislike(self),
+            "likeCount": self.get_likes_count(self),
+            "dislikeCount": self.get_dislikes_count(self)
+        }
+
+        return mapped_data
+
+    def get_favorites(self, obj):
+        mapped_data = {
+            "favorite": self.get_favorite(self),
+            "favoritesCount": obj.favoritesCount,
+        }
+
+        return mapped_data
+
     ratings = serializers.SerializerMethodField()
 
     class Meta:
         model = Article
         fields = (
             'slug', 'title', 'description', 'body', 'created_at',
-            'updated_at', 'author', 'ratings', 'tagList', 'like', 'dislike',
-            'likesCount', 'dislikesCount', 'comments', 'favorite',
-            'favoritesCount', 'readtime'
+            'updated_at', 'author', 'comments', 'tagList',
+            'ratings', 'like_info', 'favorites', 'readtime'
         )
 
 

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -83,9 +83,8 @@ class ListCreateArticleAPIView(ListCreateAPIView):
         article["author"] = request.user.pk
         serializer = self.serializer_class(
             data=article,
-            remove_fields=['like', 'created_at', 'updated_at',
-                           'favorite', 'dislike', 'likesCount',
-                           'dislikesCount', 'ratings'])
+            remove_fields=['like_info', 'created_at', 'updated_at',
+                           'favorites', 'ratings'])
         serializer.is_valid(raise_exception=True)
         article = serializer.save(author=request.user)
         data = serializer.data
@@ -120,10 +119,9 @@ class ListCreateArticleAPIView(ListCreateAPIView):
         paginator.page_size = page_limit
         result = paginator.paginate_queryset(articles, request)
         serializer = ArticleSerializer(result, many=True,
-                                       remove_fields=['like',
+                                       remove_fields=['like_info',
                                                       'comments',
-                                                      'favorite',
-                                                      'dislike',
+                                                      'favorites',
                                                       'ratings'])
         response = paginator.get_paginated_response({
             "articles": serializer.data
@@ -141,14 +139,14 @@ class RetrieveUpdateArticleAPIView(GenericAPIView):
     serializer_class = ArticleSerializer
 
     def retrieve_article(self, slug):
-            """
-            Fetch one article
-            """
-            try:
-                article = Article.objects.get(slug=slug)
-                return article
-            except Article.DoesNotExist:
-                raise ArticleNotFound
+        """
+        Fetch one article
+        """
+        try:
+            article = Article.objects.get(slug=slug)
+            return article
+        except Article.DoesNotExist:
+            raise ArticleNotFound
 
     def get(self, request, slug):
         """
@@ -177,10 +175,8 @@ class RetrieveUpdateArticleAPIView(GenericAPIView):
                 instance=article,
                 data=request.data,
                 partial=True,
-                remove_fields=['like', 'created_at', 'updated_at',
-                               'favorite', 'dislike', 'likesCount',
-                               'dislikesCount',
-                               'ratings']
+                remove_fields=['like_info', 'created_at', 'updated_at',
+                               'favorites', 'ratings']
             )
             serializer.is_valid(raise_exception=True)
             article = serializer.save()
@@ -312,8 +308,6 @@ class LikeDislikeView(GenericAPIView):
         """
         A method to delete a vote for a certain article
         """
-
-        # def get_vot_response(votetype):
 
         response, voted = self.process_vote_type(request, slug, vote_type)
         if voted:

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -137,13 +137,6 @@ AUTHENTICATION_BACKENDS = (
     'social_core.backends.twitter.TwitterOAuth',
     'django.contrib.auth.backends.ModelBackend',
 )
-# email settings
-EMAIL_BACKEND = os.getenv('EMAIL_BACKEND')
-EMAIL_HOST = os.getenv('EMAIL_HOST')
-EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
-EMAIL_PORT = os.getenv('EMAIL_PORT')
-EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
-EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS')
 
 DOMAIN = os.getenv("DOMAIN")
 VERIFICATION_URL = DOMAIN+'/api/users/activate/'

--- a/authors/utils/notification_handlers.py
+++ b/authors/utils/notification_handlers.py
@@ -98,7 +98,7 @@ def email_notification_handler(user, description):
     send_mail(
         "User Notification",
         '',
-        settings.EMAIL_HOST_USER,
+        settings.DEFAULT_EMAIL,
         [user.user.email],
         html_message=html_content)
 


### PR DESCRIPTION
**Description**

The PR fixes the response being returned when a user likes/dislikes and favorites an article. The response is embedded in a dictionary

**The working endpoints include:**
```
POST api/articles/{slug}/{vote_verb}/
DELETE api/articles/{slug}/{vote_verb}/
GET api/articles/{slug}/
```
* Ensure that a user can be able to post a like or dislike
* Ensure a user can be able to remove like/dislike from an article
* Ensure that user can be able to get likes/dislikes of articles

### How can this be manually tested?

**After cloning the repo:-**
**Test with postman**
Sign up a user, login, grub the token and add it to authorization:
```
$ git checkout  ft-like-dislike-165305762
$ python manage.py runserver
```
**To run tests on terminal**
```
$ python manage.py test authors/apps/articles
```
### What are the relevant pivotal tracker stories?
[#166044739](https://www.pivotaltracker.com/n/projects/2326460/stories/166044739)

### Screenshots
<img width="1123" alt="Screenshot 2019-05-16 at 12 13 17" src="https://user-images.githubusercontent.com/45788436/57842214-c0a01700-77d4-11e9-991e-b76367cd97c3.png">
<img width="1123" alt="Screenshot 2019-05-16 at 12 13 30" src="https://user-images.githubusercontent.com/45788436/57842216-c0a01700-77d4-11e9-9c4e-9a0a93cb32a9.png">
