### PR TITLE
#166044739 fix likes|dislikes and favorites

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -84,9 +84,8 @@ class ListCreateArticleAPIView(ListCreateAPIView):
         article["author"] = request.user.pk
         serializer = self.serializer_class(
             data=article,
-            remove_fields=['like', 'created_at', 'updated_at',
-                           'favorite', 'dislike', 'likesCount',
-                           'dislikesCount', 'ratings'])
+            remove_fields=['like_info', 'created_at', 'updated_at',
+                           'favorites', 'ratings'])
         serializer.is_valid(raise_exception=True)
         article = serializer.save(author=request.user)
         data = serializer.data
@@ -121,10 +120,9 @@ class ListCreateArticleAPIView(ListCreateAPIView):
         paginator.page_size = page_limit
         result = paginator.paginate_queryset(articles, request)
         serializer = ArticleSerializer(result, many=True,
-                                       remove_fields=['like',
+                                       remove_fields=['like_info',
                                                       'comments',
-                                                      'favorite',
-                                                      'dislike',
+                                                      'favorites',
                                                       'ratings'])
         response = paginator.get_paginated_response({
             "articles": serializer.data
@@ -142,14 +140,14 @@ class RetrieveUpdateArticleAPIView(GenericAPIView):
     serializer_class = ArticleSerializer
 
     def retrieve_article(self, slug):
-            """
-            Fetch one article
-            """
-            try:
-                article = Article.objects.get(slug=slug)
-                return article
-            except Article.DoesNotExist:
-                raise ArticleNotFound
+        """
+        Fetch one article
+        """
+        try:
+            article = Article.objects.get(slug=slug)
+            return article
+        except Article.DoesNotExist:
+            raise ArticleNotFound
 
     def get(self, request, slug):
         """
@@ -178,10 +176,8 @@ class RetrieveUpdateArticleAPIView(GenericAPIView):
                 instance=article,
                 data=request.data,
                 partial=True,
-                remove_fields=['like', 'created_at', 'updated_at',
-                               'favorite', 'dislike', 'likesCount',
-                               'dislikesCount',
-                               'ratings']
+                remove_fields=['like_info', 'created_at', 'updated_at',
+                               'favorites', 'ratings']
             )
             serializer.is_valid(raise_exception=True)
             article = serializer.save()
@@ -226,7 +222,7 @@ class RetrieveUpdateArticleAPIView(GenericAPIView):
                 status.HTTP_403_FORBIDDEN)
         return Response({
             "message": "Article '{}' deleted".format(article.title)},
-                        status.HTTP_200_OK)
+            status.HTTP_200_OK)
 
 
 class FetchTags(GenericAPIView):


### PR DESCRIPTION
**Description**

The PR fixes the response being returned when a user likes/dislikes and favorites an article. The response is embedded in a dictionary

**The working endpoints include:**
```
POST api/articles/{slug}/{vote_verb}/
DELETE api/articles/{slug}/{vote_verb}/
GET api/articles/{slug}/
```
* Ensure that a user can be able to post a like or dislike
* Ensure a user can be able to remove like/dislike from an article
* Ensure that user can be able to get likes/dislikes of articles

### How can this be manually tested?

**After cloning the repo:-**
**Test with postman**
Sign up a user, login, grub the token and add it to authorization:
```
$ git checkout  ft-like-dislike-165305762
$ python manage.py runserver
```
**To run tests on terminal**
```
$ python manage.py test authors/apps/articles
```
### What are the relevant pivotal tracker stories?
[#166044739](https://www.pivotaltracker.com/n/projects/2326460/stories/166044739)

### Screenshots
<img width="1123" alt="Screenshot 2019-05-16 at 12 13 17" src="https://user-images.githubusercontent.com/45788436/57842214-c0a01700-77d4-11e9-991e-b76367cd97c3.png">
<img width="1123" alt="Screenshot 2019-05-16 at 12 13 30" src="https://user-images.githubusercontent.com/45788436/57842216-c0a01700-77d4-11e9-9c4e-9a0a93cb32a9.png">
